### PR TITLE
blog(trnrand): editorial revision pass — Mermaid diagram, speedup callout, tightened Numbers

### DIFF
--- a/docs/blog/posts/2026-04-15-trnrand-four-engine-rng.md
+++ b/docs/blog/posts/2026-04-15-trnrand-four-engine-rng.md
@@ -67,6 +67,18 @@ across three of them:
   engines"; it's "the RNG output doesn't need to leave SBUF to be
   consumed by the next stage."
 
+```mermaid
+flowchart LR
+  CTR[("Counter<br/>(P, 1) uint32")]
+  GPS["GpSimd<br/>Philox 4×32-10<br/>10 rounds"]
+  U[("Uniform<br/>uint32 stream")]
+  VE["Vector Engine<br/>Box-Muller<br/>cos / sin / log / sqrt"]
+  N[/"Normals<br/>SBUF-resident"/]
+  DS["Downstream<br/>(trnfft STFT noise,<br/>trnblas stochastic trace)"]
+  CTR --> GPS --> U --> VE --> N
+  N -.no HBM round-trip.-> DS
+```
+
 Philox was chosen specifically because it is stateless: outputs are a pure
 function of `(counter, key)`. Partition-axis splitting on Trainium's 128-
 lane tile is then trivially correct — lane `i` gets counter range `[i·N,
@@ -156,6 +168,15 @@ Every scalar fed into a Vector Engine op (the `1e-10` clamp, the `-2.0`,
 the `2π`) is materialized as a `(P, 1)` vector-immediate up front. The
 reason is in the next section.
 
+!!! info "Why the next section exists"
+    The full curated NKI test suite runs in **~7 seconds on
+    `ubuntu-latest`** via `TRNRAND_USE_SIMULATOR=1 pytest -m nki_simulator`,
+    versus **~2 minutes** for the equivalent hardware path (SSM round-trip
+    + cold NEFF compile on trn1.2xlarge) — about **17× faster iteration**.
+    Without it, two failed decompositions plus a precision-loss trace
+    would have been several hours of hardware time rather than a single
+    afternoon.
+
 ## What didn't work
 
 Three things, two of them algorithmic and one structural. All three are
@@ -230,30 +251,15 @@ above. Tracked in
 
 ## Numbers
 
-There are no hardware speed numbers worth publishing yet, for the
-reason in the section above — the kernel runs, but the output is
-wrong until aws-neuron-sdk#1308 lands. This section inverts the
-usual blog-post ordering and leads with correctness instead. Three
-concrete numbers from 0.3.0:
+No hardware speed numbers worth publishing yet — see above for why.
+What's verifiable today:
 
-- **CPU reference: Salmon SC'11 test vectors, 3/3 exact.** The
-  `philox4x32_reference` path in `trnrand.nki.dispatch` matches all
-  three published test vectors from Salmon et al., SC'11 bit-exactly.
-  This is the oracle the NKI kernel is validated *against*.
-- **CPU reference: 100,000-sample mean 0.5000 ± 0.01, variance 1/12
-  ± 0.005.** Distributional tests in
-  `tests/test_nki_philox.py::TestPhiloxReference`.
-- **NKI kernel: simulator 4/6 xfail, hardware 3/3 fail.** All
-  attributable to aws-neuron-sdk#1308. No speedup number to report
-  until that lands.
-
-One cost number worth calling out: the CPU simulator loop
-(`TRNRAND_USE_SIMULATOR=1 pytest -m nki_simulator`) runs the full
-curated NKI test suite in **~7 seconds on `ubuntu-latest`**. The
-equivalent hardware run via SSM on trn1.2xlarge costs ~2 minutes
-(cold NEFF compile + SSM round-trip) — about 17× slower. That's
-the "seconds per cycle vs minutes on hardware" number, and it's why
-the bug above was trackable at all.
+| Measurement                                              | Value                            | Source                                          |
+|----------------------------------------------------------|----------------------------------|-------------------------------------------------|
+| Salmon SC'11 test vectors, CPU reference                 | 3 / 3 exact                      | `tests/test_nki_philox.py::TestPhiloxReference` |
+| 100k-sample uniform, CPU reference                       | mean 0.5000 ± 0.01, var 1/12 ± 0.005 | same file, distributional tests             |
+| NKI kernel on simulator                                  | 4 / 6 xfail (aws-neuron-sdk#1308) | `tests/test_nki_sim.py`                        |
+| NKI kernel on trn1 hardware                              | 3 / 3 fail (same root cause)     | `tests/test_nki_philox.py::TestPhiloxNKI`       |
 
 ## What's next
 


### PR DESCRIPTION
## Summary

Editorial revision pass on the already-merged trnrand post (currently live at [trnsci.dev](https://trnsci.dev/blog/trnrand-rng-is-a-four-engine-workload-if-the-silicon-lets-you-say-so/)), per the updated brief.

## Changes

1. **Mermaid diagram** of the four-engine RNG dataflow added at the end of "What the architecture suggests" — counter → GpSimd Philox → uniform stream → Vector Engine Box-Muller → SBUF-resident normals → downstream consumer (with explicit "no HBM round-trip" dashed edge). Anchors the post's spine visually.

2. **Simulator speedup datapoint promoted** out of the Numbers section into an `!!! info` admonition titled "Why the next section exists", placed at the end of Implementation. Reads as the transition into "What didn't work" — without the ~17× faster iteration, that section's debugging walk would have been a multi-day hardware slog.

3. **Numbers section tightened.** Opener now uses your exact phrasing (*"No hardware speed numbers worth publishing yet — see above for why. What's verifiable today:"*). Bullets replaced with a measurement table (metric / value / source). Cost-of-iteration paragraph removed since it now lives in the admonition above.

## Word count

1953 (was 1932). Still under the 2000-word cap. Mermaid + table do not count toward words.

## Voice check

Re-read against the four axes in the new brief section:

- **Fair:** cuRAND framed as "reasonable shape on an SM-style architecture"; Mersenne Twister noted as valid elsewhere; PyTorch fallback credited as the user-visible path today.
- **Objective:** specific numbers (1764265896 vs 1764265856, 2²⁴, aws-neuron-sdk#1308), version-pinned (v0.3.0), named test cases (test_mul32_simulator_matches_numpy, etc.).
- **Self-effacing:** opens with "kernels do not currently produce correct numerical output" and walks through two failed decompositions before the actual wall.
- **Lightly funny when warranted:** deadpan throughout; closing line *"the silicon just needs one more op to let the library say it out loud"* has a touch of wry. No manufactured humor.

No prose changes needed for voice — the original post already reads as self-effacing candor per the new voice section.

## Test plan

- [ ] Verify Mermaid renders on the live site (material theme supports it per the brief).
- [ ] Verify `!!! info` admonition renders as expected.
- [ ] Confirm table renders with four measurement rows.
- [ ] Confirm word count still under 2000 after render.