### PR TITLE
blog(trntensor): round-2 editorial — lede split + redundant code comments

### DIFF
--- a/docs/blog/posts/2026-04-15-trntensor-kernel-boundary-as-api.md
+++ b/docs/blog/posts/2026-04-15-trntensor-kernel-boundary-as-api.md
@@ -6,7 +6,9 @@ comments: true
 
 # trntensor: when the kernel boundary is the API
 
-trntensor Phase 1 landed: the 2-index and batched `nc_matmul` NKI kernels validate on trn1, `ContractionPlan.backend` reports `"nki"` when shapes qualify, and two fused multi-step primitives — a DF-MP2 correlation-energy kernel and a 4-index AO→MO integral transform — run the contract → elementwise → reduce and contract → SBUF-resident → contract patterns as single NKI programs. The architectural point isn't "einsum on Trainium." It's that the kernel boundary is the design surface: what cuTENSOR hides behind a `Plan` object, NKI asks you to lay out in source. More work, but also where a tensor library can become a cuTENSOR superset rather than a port.
+trntensor Phase 1 landed. The 2-index and batched `nc_matmul` NKI kernels validate on trn1. `ContractionPlan.backend` now reports `"nki"` when shapes qualify, `"pytorch"` otherwise — plan-time transparency about where work will actually land. And two fused multi-step primitives — a DF-MP2 correlation-energy kernel and a 4-index AO→MO integral transform — run contract → elementwise → reduce and contract → SBUF-resident → contract as single NKI programs.
+
+The architectural point isn't "einsum on Trainium." It's that the kernel boundary is the design surface: what cuTENSOR hides behind a `Plan` object, NKI asks you to lay out in source. More work, but also where a tensor library can become a cuTENSOR superset rather than a port.
 
 <!-- more -->
 
@@ -65,7 +67,7 @@ The `mp2_energy_kernel`, per `(i, j)` orbital pair:
 def mp2_energy_kernel(B, eps_occ, eps_vir):
     NOCC, NVIR, NAUX = B.shape
     partial = nl.ndarray((NOCC, NOCC), dtype=nl.float32, buffer=nl.shared_hbm)
-    ev = nl.load(eps_vir[0:NVIR, 0:1])  # 2D for unambiguous partition dim
+    ev = nl.load(eps_vir[0:NVIR, 0:1])
 
     for i in nl.affine_range(NOCC):
         Bi_t = nl.load_transpose2d(B[i, 0:NVIR, 0:NAUX])
@@ -81,13 +83,11 @@ def mp2_energy_kernel(B, eps_occ, eps_vir):
             nisa.nc_matmul(dst=psum_T,  stationary=Bi_t, moving=Bj_t, accumulate=True)
             nisa.nc_matmul(dst=psum_Tt, stationary=Bj_t, moving=Bi_t, accumulate=True)
 
-            # PSUM → SBUF (NKI 0.3.0 requires explicit copy)
             t   = nl.ndarray((NVIR, NVIR), dtype=B.dtype, buffer=nl.sbuf)
             t_T = nl.ndarray((NVIR, NVIR), dtype=B.dtype, buffer=nl.sbuf)
             nisa.tensor_copy(src=psum_T,  dst=t)
             nisa.tensor_copy(src=psum_Tt, dst=t_T)
 
-            # Vector Engine: Δ_ab = (ε_i+ε_j) - ε_a - ε_b
             denom = nl.subtract(nl.subtract(eo_sum, ev), ev.reshape((1, NVIR)))
 
             # term = T * (2T - T^T) / Δ  (divide-as-reciprocal for 0.3.0)


### PR DESCRIPTION
Round 2 editorial pass on the trntensor kernel-boundary post. Surgical — only the three asks from the review. PR-only; Scott reviews and merges.

## Changes

### 1. Lede split

The 70-word opener was one sentence compressing four announcements. Now four shorter sentences:

1. 'trntensor Phase 1 landed.'
2. The 2-index and batched `nc_matmul` kernels validate on trn1.
3. `ContractionPlan.backend` reports nki/pytorch — with a phrase about plan-time transparency.
4. The two fused multi-step primitives.

The 'architectural point isn't \"einsum on Trainium\"' line starts its own paragraph, as suggested.

### 2. Three redundant code comments dropped

In the `mp2_energy_kernel` sample:

- `# 2D for unambiguous partition dim` — gone (the 1D-load issue is covered in 'What didn't work')
- `# PSUM → SBUF (NKI 0.3.0 requires explicit copy)` — gone (covered in the `nl.copy` bullet)
- `# Vector Engine: Δ_ab = (ε_i+ε_j) - ε_a - ε_b` — gone (the code expresses it)

Kept the comments that name operations not obvious from the code itself:
- `# Two nc_matmul in PSUM: T = Bi @ Bj.T and T^T = Bj @ Bi.T`
- `# term = T * (2T - T^T) / Δ  (divide-as-reciprocal for 0.3.0)`
- `# Scalar accumulator — avoids 0-D SBUF allocation`

### 3. Dry voice moments preserved

- 'a good way to ship a framework that's worse at two things than two libraries would be at one each' — untouched
- 'The compiler is targeting trn2 because our instance is a trn1, which is either an impressive feat of optimism or a missing guard somewhere' — untouched

## Unchanged

- Mermaid diagram, `## Fit assessment` H2, numbers table, #33 profile citations, Phase-tracker links — all as merged.

## Stats

- Word count: 2,003 → 1,981 (under the 2,000 cap)
- Nine required H2 sections in order, plus supplementary `## Fit assessment`
- Authorless; no `authors:` frontmatter

## Test plan

- [x] `wc -w` under 2,000
- [x] Nine required H2s present and in order
- [x] Both dry voice lines intact (grep confirms)
- [ ] `mkdocs build --strict` (CI)
- [ ] Scott editorial review