### PR TITLE
docs: incorporate post-FP64 thesis and technical plan v3 insights

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
     rev: v2.3.0
     hooks:
       - id: codespell
-        args: ["--ignore-words-list", "crate,nd,te,coo,bnd,BLAS,blas"]
+        args: ["--ignore-words-list", "crate,nd,te,coo,bnd,BLAS,blas,VectorE,TensorE,ScalarE,GpSimdE,GpSimd,SyncE"]
         exclude: "^(LICENSE|conda-recipes/|trnfft/|trnblas/|trnrand/|trnsolve/|trnsparse/|trntensor/)"
 
 # Sub-project directories (trnfft/, trnblas/, etc.) are excluded — each has

--- a/docs/TECHNICAL_BRIEF.md
+++ b/docs/TECHNICAL_BRIEF.md
@@ -1,0 +1,121 @@
+# trnsci technical brief — post-FP64 positioning and architectural principles
+
+*For sub-project maintainers. Paste the shared section plus your library's section into any agent context that involves architectural decisions, new kernel design, API additions, or benchmarking.*
+
+---
+
+## Shared context (paste for all six libraries)
+
+### The thesis
+
+trnsci is the reference implementation for **post-FP64 scientific computing** on AWS Trainium — not just cuX equivalents ported to Neuron. The numerical-analysis community has been building the framework for this hardware for over a decade (Carson–Higham iterative refinement, Ozaki-scheme FP64 emulation, Croci–Higham–Mary stochastic rounding, Halko–Martinsson–Tropp randomized NLA); trnsci is the library that treats these ideas as the default API rather than exotic overlays on an FP64-centric LAPACK stack.
+
+The competitive context: H100 FP64-tensor:BF16-tensor throughput is 1:14.8. B200 is 1:61. B300 Ultra is under 1:5000; cuBLAS in CUDA 13 now emulates FP64 DGEMM via the Ozaki scheme on FP8 tensor cores. Trainium was designed without an FP64 legacy to protect. It is not behind this trend — it codified it in 2020.
+
+The CUDA-equivalents framing gets users in the door and stays valid. The post-FP64 thesis is what the project is actually about.
+
+### Four architectural principles
+
+These affect how kernels should be designed, not just how the project is positioned.
+
+**1. PSUM is a free FP32 accumulator.** PSUM is wider than SBUF (FP32 vs BF16/FP8), exclusively written by the systolic array (deterministic order), and addressable by every other engine. After a BF16 matmul writes into PSUM at FP32, VectorE can compute the BF16 split and the residual in-place — an error-free split — while the next TensorEngine matmul proceeds on the next tile. This is the Ogita–Rump–Oishi Dot2 construction at systolic scale. For iterative refinement, PSUM is the residual buffer at higher precision than the working computation. Kernels should use this deliberately, not accidentally.
+
+**2. Engine concurrency is free adaptivity.** The four engines (Tensor, Vector, Scalar, GpSimd) run independently. Adaptive decisions — Ozaki stopping criteria, GMRES-IR residual norms, randomized sketch quality estimates — can run on VectorE/GpSimdE while the TensorEngine runs the next matmul. The marginal cost of adaptivity is near zero when it runs on the idle engine.
+
+**3. Stochastic rounding is in the ISA and should be used.** Per-instruction SR is a first-class NKI primitive (`nisa.activation(..., round_mode="stochastic")`). Connolly–Higham–Mary (SIAM J. Sci. Comput., 2021) proved SR rounding errors are mean-zero, replacing Wilkinson's worst-case n·u error bound with a √n·u probabilistic bound. For BF16 (u ≈ 2⁻⁸), any dot product or reduction of length n ≥ ~300 needs SR for correct convergence — without it, BF16 Krylov stagnates. This is a correctness requirement, not an optimization.
+
+**4. Determinism is structural.** The TensorEngine has a fixed reduction order; the compiler statically schedules all instructions. Bitwise reproducibility is a structural property of every trnsci kernel given a fixed seed — not a ReproBLAS-style overlay. Kernels should document their reproducibility guarantees explicitly.
+
+### The API direction
+
+The suite is building toward a **solve-to-target-error contract**, not a precision knob:
+
+```python
+x, info = trnsolver.solve(A, b, target_forward_error=1e-10)
+```
+
+trnsci selects factorization precision, Ozaki split count, IR iteration count, and SR policy automatically. The `info` struct returns the achieved error bound, the theorems invoked, and the precision trajectory.
+
+The `precision=` kwarg (trnfft, trntensor), `iterative_refinement=True` (trnsolver), and return tuples `(x, iters, res)` (cg/gmres) are scaffolding for this. Every API addition should ask: does this fit the `target_forward_error` contract, or is it a dead end that adds precision knobs without accuracy guarantees?
+
+### What changes about how you write code
+
+- **Admit what doesn't fit.** Long MD trajectories, general unstructured CSR SpMV, classical CCSD(T) — these are honest non-fits for this hardware. Saying so is more credible than pretending otherwise.
+- **Name SR when you use it.** If a kernel relies on stochastic rounding for convergence, say so in the docstring and in the blog post.
+- **Benchmark achieved forward error, not just wall clock.** A 10× faster result at 4 bits less precision is a different answer, not a 10× win.
+- **Vintage-match comparisons.** A10G vs trn1, H100 vs trn2, GB200 vs trn3. Not cherry-picked shapes where Trainium looks best.
+- **The "What didn't work" section is more important than the benchmark table.** Specific, nameable failures — 303 NEFF compile workdirs, distribution mean 0.31 vs 0.5, 215× slower than baseline — are the most valuable things the blog publishes.
+
+---
+
+## Library-specific sections
+
+### trnfft
+
+**Fit:** Partial. Fits well at small N via DFT-as-GEMM (the DFT matrix IS a matmul; one Tensor-engine call replaces log₂(N) butterfly stages). At larger N, error accumulates across log₂(N) butterfly stages — O(u log N) even before overflow. Compensated butterfly (`precision="kahan"`) addresses this; iterative FFT refinement (compute in BF16, estimate residual at FP32 via PSUM, refine) is the research direction.
+
+**Architectural fit:** The partition-dim flattening across `total_groups × batch` is the right idiom for parallel butterfly stages. The four-engine concurrency (TE for twiddle multiply, VE for butterfly combination, DMA prefetching next twiddles) is the right kernel structure. Radix-4 exploits W₄ = {1,−1,i,−i} needing no multiplications; radix-8 exploits W₈'s irrational entries to earn Tensor Engine work.
+
+**What doesn't fit honestly:** Non-power-of-2 FFTs via Bluestein chain three power-of-2 FFTs and accumulate error multiplicatively. `precision="double"` is the escape hatch, at the cost of CPU roundtripping. Don't claim Bluestein-at-BF16 is production-accurate for large N.
+
+**Phase 2 direction:** Complete Kahan butterfly hardware characterization (#58). Iterative FFT refinement is a genuine research contribution — no one has published it on a production deterministic systolic array.
+
+---
+
+### trnblas
+
+**Fit:** Clean. Dense LU/QR/Cholesky/GEMM are the showcase workload. The fused DF-MP2 energy kernel is the current flagship: one NEFF, SBUF-resident intermediates through the full T*(2T−Tᵀ)/Δ expression, one HBM store per (i,j) pair.
+
+**Phase 2 keystone:** trnblas#22 — double-double FP64 GEMM (compensated matmul exploiting PSUM as the FP32 accumulator). This unblocks the entire suite's Phase 2: trnsolver iterative refinement, trntensor `precision="dd"`, and the path to HPL-MxP. The Ozaki-scheme direction (adaptive split decomposition with VectorE residual estimation running concurrently with TensorEngine splits) is the long-term target.
+
+**HPL-MxP:** A trnsci HPL-MxP submission on Trn2 UltraServer is a Phase 2/3 goal — the first Trainium-era HPL-MxP result. The recipe: LU factorization in BF16, FP32 PSUM residual via compensated matmul, GMRES-IR outer loop.
+
+**What doesn't fit honestly:** The per-call 100 ms Neuron XLA dispatch overhead is real and shapes kernel granularity decisions (batched-pair vs per-pair). Don't claim dispatch improvements that aren't measured.
+
+---
+
+### trnrand
+
+**Fit:** Clean. Monte Carlo is famously low-precision-tolerant because statistical error (1/√N) usually dominates arithmetic error. SR is the correct default for any accumulation of random draws.
+
+**Architectural fit:** GpSimd is the right home for Philox and Threefry — 8 fully-programmable 512-bit vector cores running straight-line integer arithmetic, none of which requires the Tensor Engine. Box-Muller transcendentals belong on VectorE. SBUF-resident output for downstream fusion (trnfft noise injection, trnblas stochastic trace) is the key performance argument.
+
+**Philox status:** Blocked on aws-neuron-sdk#1308 (no exact integer arithmetic above 2²⁴). Threefry4×32-20 is the hardware-validated path — designed for exactly this class of hardware constraint. Philox validation reopens when AWS ships a bitwise-exact primitive.
+
+**What doesn't fit honestly:** Don't publish Philox hardware benchmarks until aws-neuron-sdk#1308 resolves. The distribution mean 0.31 vs expected 0.5 is documented; pretending otherwise would be a credibility problem.
+
+---
+
+### trnsolver
+
+**Fit:** Clean for dense eigensolvers and Krylov. Jacobi's batched-sweep form (n/2 rotations commuting on disjoint pairs → one kernel dispatch per round → stable NEFF cache) is the canonical NKI-native eigensolver. Householder-QR for eigh and Schur fits once the NEFF compile graph is stable. GMRES-IR (BF16 inner solve, FP32 residual via PSUM, outer refinement) is the direction for general linear systems.
+
+**Carson–Higham framing:** trnsolver's `solve_spd(iterative_refinement=True)` is already in the Carson–Higham three-precision regime (κ ≲ 10⁷). The Phase 2 goal is extending this to general systems + GMRES inner solve, and exposing it as `target_forward_error`.
+
+**Phase 2/3 opportunity:** Randomized eigensolvers (Nakatsukasa–Tropp sRR, SIAM SIMAX 45(2), 2024) use non-orthogonal bases and only need subspace-embedding-quality arithmetic — exactly what BF16+FP32-accumulate provides. Reported 10× over MATLAB eigs at FP64; 50–100× play at BF16. Natural next API: `eigh_randomized(A, k, oversampling=10)`.
+
+**What doesn't fit honestly:** NEFF compile overhead at 303 workdirs per test run is a documented result. Every architecture post should be honest that the simulator validates kernel math but only hardware validates host-integration shape.
+
+---
+
+### trnsparse
+
+**Fit:** Clean after BSR reformulation. The key architectural fact: the Tensor Engine is a 128×128 systolic array; `nisa.nc_matmul` consumes a 128×K×N tile. CSR's arbitrary-pattern indirect gather is hostile to systolic arrays. BSR at 128×128 — one `nc_matmul` per nonzero block — is the native format.
+
+**New pattern worth codifying:** `chebyshev_bsr` and `richardson_bsr` are fixed-K iterations with **no inner products**. Unlike CG or GMRES, they do not require dot products of length n at each step. For low-precision regimes, SR-tolerant convergence without accumulating inner-product error is the correct design pattern. This should be documented as a principled choice, not an omission.
+
+**BLR/HODLR direction:** For kernels, integral equations, covariance matrices, and dense-PDE discretizations, hierarchical-matrix compression maps cleanly — store off-diagonal low-rank blocks in BF16, diagonal blocks in FP32. Carson–Chen–Liu (SIAM J. Sci. Comput., 2024) proves the mixed-precision HODLR error stays bounded. This is the Phase 2+ opportunity.
+
+**What doesn't fit honestly:** Fully unstructured CSR SpMV with near-diagonal structure (random graphs, FEM on unstructured meshes) is a shape mismatch. Recommend CPU fallback for those cases and say so.
+
+---
+
+### trntensor
+
+**Fit:** Clean. The DF-MP2 end-to-end pipeline — AO→MO transform, pair-energy contractions, elementwise denominators, reductions — is the current flagship workflow. The fused multi-step primitives (contract → SBUF-resident → contract) are the key design: what cuTENSOR hides behind an opaque Plan, NKI exposes as writable kernel source.
+
+**Dispatch granularity is the architecture.** The ~100 ms Neuron XLA dispatch overhead (current, pre-SDK-2.30) determines kernel boundary decisions: one dispatch per loop, not one per iteration. The `_try_batched_multi_einsum` detection and K/M/N-tiling are both responses to this. Under `torch.compile` + neuron backend (SDK 2.30), the overhead drops to ~µs — kernel boundaries can be revisited then.
+
+**`precision=` as scaffolding.** The `precision=` kwarg (`fast`/`kahan`/`dd`) is scaffolding for the `target_forward_error` API direction. `precision="dd"` is gated on trnblas#22. When that lands, trntensor's multi-contraction path gets FP32-accuracy output from BF16 inputs via compensated matmul.
+
+**What doesn't fit honestly:** 3+ operand einsums that fall through to `torch.einsum` lose both the optimal-order choice and the fused-DAG opportunity. Document this explicitly rather than claiming `einsum()` handles all cases.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -6,48 +6,62 @@ The detailed version of this roadmap, with tracking labels and cross-project dep
 
 ## Phase 1 — Single-chip correctness
 
-Every public API runs through a real NKI kernel on a trn1 or trn2 NeuronCore, matching the PyTorch reference within float tolerance. Today, across the suite, the NKI kernels are scaffolded but dispatch falls back to PyTorch. Phase 1 replaces the stubs with real kernels and validates them against published test vectors and cross-library integration demos.
+Every public API runs through a real NKI kernel on a trn1 or trn2 NeuronCore, matching the PyTorch reference within float tolerance. Phase 1 replaces dispatch stubs with real kernels and validates them against published test vectors and cross-library integration demos.
 
-**Data-parallel multi-chip** (replica per chip, embarrassingly parallel) falls out of Phase 1 automatically. No new code beyond a worker loop.
+**Data-parallel multi-chip** (replica per chip, embarrassingly parallel) falls out of Phase 1 automatically — no new code beyond a worker loop.
 
 ## Phase 2 — Precision and numerical validation
 
-Trainium's Tensor Engine is FP32-only. For workloads where that matters — quantum chemistry in particular — Phase 2 delivers double-double FP64 emulation, Kahan / Neumaier compensated summation for long reduction chains, and iterative-refinement variants where they beat the eigendecomposition-based approaches.
+The Carson–Higham three-precision iterative-refinement framework, Ozaki-scheme FP64 emulation on BF16/FP8 tensor units, and stochastic-rounding-enabled Krylov solvers. Concretely:
 
-Validation targets include DF-MP2 energies to nanohartree tolerance against PySCF, and long-chain FFT round-trips against scipy.
+- **trnblas#22 — double-double FP64 GEMM** (keystone). A `nc_matmul_compensated` kernel exploiting PSUM as a free FP32 accumulator to deliver FP32-accuracy output from BF16 inputs at ~2× the work of naive BF16 matmul. This unblocks trnsolver iterative refinement, trntensor `precision="dd"`, and the Phase 2 direction for every library that does linear algebra.
+- **Compensated reduction chains** (Kahan/Neumaier) in trnsolver cg/gmres inner products and trntensor contractions.
+- **SR-enabled BF16 Krylov** — stochastic rounding is already in the NKI ISA; wiring it as the default for long reductions (n ≫ √(1/u) ≈ 300 for BF16) turns convergence from aspirational to structural.
+- **`target_forward_error` API contract** — unify trnsolver's `iterative_refinement=True`, trntensor's `precision=`, and trnfft's `precision=` into a cross-package `target_forward_error` kwarg. The user states "solve to ε"; trnsci selects factorization precision, Ozaki split count, and IR iterations automatically, returning an achieved-error bound.
 
-Not every library needs Phase 2. `trnrand` is precision-neutral; `trnsparse` and `trntensor` inherit their precision story from `trnblas`.
+Validation targets: DF-MP2 to nanohartree against PySCF at aug-cc-pVDZ (currently passing at cc-pVDZ), and HPL-MxP single-node on Trn2.
 
-## Phase 3 — Single-chip performance
+## Phase 3 — Single-chip performance + randomized NLA flagship
 
-The NKI path becomes meaningfully faster than the PyTorch fallback and competitive on a per-dollar basis with NVIDIA on vintage-matched instances (A10G vs trn1, H100 vs trn2).
+**Performance:** NKI path becomes meaningfully faster than the PyTorch fallback and competitive per-dollar against vintage-matched NVIDIA instances (A10G vs Trn1, H100 vs Trn2, GB200 vs Trn3). Work per kernel: tile-shape sweeps, operand-stationarity choices, multi-engine scheduling, operation fusion, NEFF compile-cache reuse.
 
-Work in this phase is per-kernel: tile-shape sweeps, operand-stationarity choices, multi-engine scheduling, operation fusion, NEFF compile-cache reuse, plan and contraction-plan re-execution. Published benchmarks on each sub-project's docs page provide the CPU baseline, the vintage-matched GPU baseline, and the Trainium numbers side-by-side.
+**Randomized NLA flagship:** ship `rsvd`, `hutch_plus_plus`, and `sRR` (sketched Rayleigh–Ritz, Nakatsukasa–Tropp 2024) as named entry points — natural home in trnsolver or a new `trnrandla` sibling, using existing trnblas, trnrand, and trnsolver.qr primitives. The flagship benchmark: randomized SVD of a 10⁶-dimensional kernel matrix on Trn2 UltraServer at BF16, verified to FP32 accuracy via iterative refinement, with bitwise-reproducible output given a seed. This is the highest-visibility Phase 3 differentiator — no GPU library can match ISA-level SR + documented-deterministic systolic reduction + Ozaki adaptivity in one package.
+
+Additional Phase 3 targets: HPL-MxP multi-node submission on Trn2 UltraServer, BLR/HODLR direct solvers (trnsparse + trnblas frontal kernels), iterative FFT refinement research (trnfft Phase 2 research thread).
 
 ## Phase 4 — Model-parallel multi-chip
 
-Workloads whose tensors exceed a single chip's HBM — large-basis DF-MP2, N > 2^24 FFTs, sparse systems with >1B nonzeros — are sharded across NeuronCores within a chip and chips within an instance.
+Workloads whose tensors exceed a single chip's HBM — large-basis DF-MP2, N > 2²⁴ FFTs, sparse systems with >1B nonzeros — sharded across NeuronCores within a chip and chips within an instance. Introduces `ShardedTensor` abstractions, collective operations (blocked on `nki.collectives`, expected in Neuron SDK 2.30+), and dispatch glue transparent to the user. HPL-MxP UltraServer submission.
 
-This phase introduces sharded tensor abstractions, collective operations, and the dispatch glue that makes model-parallel operation transparent to the library user.
+Cross-instance (EFA-interconnected) multi-chip is a Phase 4 follow-up.
 
-Cross-instance (EFA-interconnected) multi-chip is a Phase 4 follow-up if demand warrants it.
+## Phase 5 — Generation-specific optimization + research
 
-## Phase 5 — Generation-specific optimization
+Trn1 (NeuronCore-v2) and Trn2/Trn3 (NeuronCore-v3) generation-specific fast paths: Trn3 MXFP8/MXFP4 microscaling as a native codepath for block-structured problems (directly applicable to mixed-precision HODLR and progressive-precision multigrid). Common Phase 3 paths stay the default; generation-specific paths are opt-in.
 
-trn1 (NeuronCore v2) and trn2 (NeuronCore v3) get fast paths that exploit their respective architectural strengths — trn2's larger SBUF, wider PSUM, and FP16 accumulate are the main levers today — without requiring the maintainer to track two separately tuned code paths.
+Research contributions back to the community: iterative FFT refinement theory, compensated systolic matmul error bounds (formal analysis for BF16+FP32-accum with ISA-level SR on a documented-deterministic array), SR-as-preconditioner analysis (Dexter et al. 2024 showed SR regularizes tall-skinny matrices — can this be formalized as a zero-memory preconditioner?), mixed-precision CCSD(T) cancellation analysis.
 
-The common Phase 3 path stays the default. Generation-specific paths are opt-in via backend selection or automatic based on runtime capability detection.
+New domains: mixed-precision multigrid (`trnpde` or trnsolver submodule, Phase 3+), scientific optimization — LBFGS/ADMM/trust-region Newton (trnsolver submodule, Phase 3+), FEAST eigensolver via contour integration (Phase 3, maps naturally onto Trn3 UltraServer's 144 chips across quadrature points).
+
+---
 
 ## Where each library is today
 
-As of 2026-04-13, two sub-projects have completed Phase 1 correctness: **trnfft** (butterfly + complex GEMM kernels, hardware-validated on trn1.2xlarge in v0.8.0) and **trnblas** (GEMM, SYRK, and fused MP2 energy reduction, hardware-validated with end-to-end DF-MP2 timings). **trnblas** additionally has PySCF validation against real chemistry at nanohartree tolerance on small molecules, which touches Phase 2 territory. **trnsolver** has published CPU baselines against LAPACK and scipy, which sets up Phase 3.
+*As of April 2026.*
 
-The remaining four sub-projects — **trnrand**, **trnsolver**, **trnsparse**, **trntensor** — have Phase 1 NKI code scaffolded in their respective `nki/dispatch.py` modules but have not yet had a hardware-validation run on trn1 / trn2. Closing the validation gap is the immediate next step across those four; progress is tracked in [trnsci/trnsci#1](https://github.com/trnsci/trnsci/issues/1).
-
-See each sub-project's docs (`trnsci.dev/<name>/`) for library-specific status.
+| Package | Version | Phase | Status |
+|---|---|---|---|
+| **trnfft** | v0.15.0 | Phase 1 ✓ / Phase 2 active | Hardware-validated on trn1.2xlarge (70/70 cases). DFT-as-GEMM fast path (up to 14× at N ≤ 256), Stockham radix-4/8 with Tensor-engine W₈, compensated butterfly in `precision="kahan"` mode. Iterative FFT refinement open as research. |
+| **trnblas** | v0.5.4 | Phase 1 ✓ | GEMM, SYRK, batched GEMM, fused DF-MP2 energy reduction hardware-validated. DF-MP2 matches PySCF to 10 µHa at cc-pVDZ on H₂O/CH₄/NH₃. FP32 precision sufficient to nanohartree at target molecules (trnblas#20 closed). Phase 2 next: double-double FP64 GEMM (trnblas#22). |
+| **trnsolver** | v0.9.0 | Phase 1 hardware-pending | Full API shipped: eigh, eigh_generalized, Cholesky/LU/QR/SVD/pinv, cg/gmres with iterative refinement (κ ≲ 10⁷, Carson–Higham regime), Schur decomposition. NKI Jacobi kernel simulator-validated; hardware validation pending. |
+| **trnsparse** | v0.4.3 | Phase 1 partial | BSRMatrix (128×128), bsr_spmm, screened_spmm, block-sparse attention, cg_bsr, chebyshev_bsr, richardson_bsr shipped. Hardware-validated via densify-then-GEMM path. Native BSR NKI kernel hardware validation pending. |
+| **trntensor** | v0.3.0 | Phase 1 hardware-pending | Einsum with greedy path planner, CP/Tucker/TT decompositions, homogeneous-contraction batching, `ShardedTensor` for output-parallel multi-chip, `to_xla`/`from_xla` residency. Hardware validation pending. |
+| **trnrand** | v0.4.1 | Phase 1 hardware-pending | Philox 4×32 and Threefry4×32-20 NKI kernels (Threefry hardware-validated for uniforms); Box-Muller NKI kernel; full distribution suite (normal, exponential, Bernoulli, etc.); Sobol/Halton/LHS QMC. Philox blocked on aws-neuron-sdk#1308. |
 
 ## How to follow along
 
-- Suite-wide coordination and cross-project dependencies: [issues on `trnsci/trnsci`](https://github.com/trnsci/trnsci/issues).
-- Per-library roadmap tracking: labels `phase-1-correctness` / `phase-2-precision` / `phase-3-perf` / `phase-4-multichip` / `phase-5-generation` on each sub-project's issue tracker.
-- Releases: each library versions independently. Current PyPI versions at [pypi.org/project/trnsci/](https://pypi.org/project/trnsci/).
+- Suite-wide coordination and cross-project dependencies: [issues on `trnsci/trnsci`](https://github.com/trnsci/trnsci/issues)
+- Per-library roadmap tracking: labels `phase-1-correctness` / `phase-2-precision` / `phase-3-perf` / `phase-4-multichip` / `phase-5-generation` on each sub-project's issue tracker
+- NKI-native migration tracking: [trnsci/trnsci#35](https://github.com/trnsci/trnsci/issues/35) — removing torch-xla, targeting Neuron SDK 2.30
+- Releases: each library versions independently. Current PyPI versions at [pypi.org/project/trnsci/](https://pypi.org/project/trnsci/)
+- Blog: [trnsci.dev/blog/](https://trnsci.dev/blog/) — retrospectives on shipped work, honest about what worked and what didn't

--- a/docs/trainium_positioning.md
+++ b/docs/trainium_positioning.md
@@ -1,52 +1,127 @@
-# Trainium between SMs and TPUs
+# Trainium as a numerical-computing substrate
 
-Accelerator architectures have historically sat on a spectrum. At one end, NVIDIA GPUs — many small cores, fine-grained SIMT, warp-level programming. At the other, Google TPUs — one very large systolic array, coarse-grained, compiler-mediated via XLA. Trainium sits in the middle of this spectrum, with NKI as the programming model that exposes both halves.
+## The competitive context
 
-This page is a reference frame, not a comparison. We are not ranking architectures — we are placing Trainium on the axis so that a programmer coming from either side knows what to expect.
+Every major silicon roadmap from 2022 onward has converged on the same architecture: a tensor-native core with FP32 accumulate on BF16/FP8/FP4 inputs, FP64 either halved, emulated, or absent. The numbers tell the story clearly:
 
-## NVIDIA SMs — fine-grained, drifting coarser
+| Chip | FP64 tensor | BF16 tensor | Ratio |
+|---|---:|---:|---:|
+| H100 SXM5 | 67 TFLOPS | 989 TFLOPS | 1:14.8 |
+| B200 | ~30 TFLOPS | 2,250 TFLOPS | 1:61 |
+| B300 Ultra | <1 TFLOPS | ~5,000 TFLOPS | <1:5000 |
+| Trn2 (per chip) | none | 79 TFLOPS BF16 | — |
+| Trn3 (per chip) | none | 2,520 TFLOPS FP8 | — |
 
-A classic CUDA program is a grid of thread blocks, each thread block a dense bundle of 32-lane warps running SIMT. The mental model is per-thread: you write one thread's view of the kernel and the hardware multiplexes many. Shared memory is explicit; synchronization is explicit; tiling is handled by the programmer or by cuBLAS / cuFFT underneath.
+cuBLAS in CUDA 13 now emulates FP64 DGEMM via the Ozaki scheme on FP8 tensor cores (NVIDIA Developer Blog, January 2026). AMD halved FP64 matrix throughput from MI300X to MI355X. Google TPU has never exposed FP64. Intel Gaudi 3, Cerebras WSE-3, SambaNova SN40L — none.
 
-Recent generations have drifted in the coarse direction. Hopper added the Tensor Memory Accelerator and asynchronous tile moves; Blackwell pushes further into tile-granularity APIs. CUDA Graphs capture whole pipelines. `cuBLASLt` and `cutlass` expose tile-sized abstractions above the per-thread view.
+Trainium was designed without an FP64 legacy to protect. It codified the post-FP64 architecture in 2020, roughly five years before the rest of the industry caught up. This is the context in which trnsci's algorithms make sense: not as workarounds for a missing FP64 path, but as the correct algorithms for hardware the industry is converging on.
 
-The direction of travel is toward larger, more compiler-scheduled units of work — but the baseline model is still "many cores doing fine-grained things".
+The HPL-MxP benchmark — which scores the fastest achievable HPC performance using hardware-native precision with certified FP64-accuracy output — delivers 4–24× over HPL-FP64 on every top-10 system. Jack Dongarra's ISC 2026 keynote stated the conclusion plainly: *"The most plausible path to effective zettascale is not brute-force FP64, but certified mixed-precision algorithms."*
 
-## Google TPU — coarse, drifting finer
+---
 
-A TPU is closer to a single very large systolic array. The programming model is XLA: you describe the computation as a dataflow graph, the compiler lays out a schedule, and the hardware executes at tile granularity. You don't write per-thread code; you write per-tensor code.
+## What Trainium actually is
 
-This favours fixed-shape, predictable workloads. XLA needs static shapes to schedule well; dynamic control flow costs recompilation.
+A Trainium2 chip contains 8 NeuronCore-v3 cores. Each NeuronCore is a heterogeneous compute engine, not a GPU SM:
 
-The recent drift is in the opposite direction of NVIDIA's. Pallas — a JAX-level programming model — gives per-tile control over memory hierarchy and compute, bringing TPU programming closer to the kernel-level mental model CUDA programmers are used to. The hardware hasn't changed, but the programmer's view of it has.
+**TensorEngine** — a 128×128 systolic array consuming a stationary matrix and a moving matrix from SBUF, always accumulating into PSUM. Delivers 158 TFLOPS FP8 / 79 TFLOPS BF16 / 20 TFLOPS FP32 per core. Supported dtypes: FP8 (E4M3/E5M2), BF16, FP16, TF32, FP32, INT8.
 
-## Trainium — tile-sized systolic plus programmable engines
+**VectorEngine** — elementwise/SIMD for axpy, LayerNorm, pooling, reductions, transcendentals with broadcast/scan semantics. On NC-v3, a new performance mode shares a memory bus with GpSimdE for 2–4× uplift on selected BF16/FP16 ops; NC-v3 also allows VectorE and ScalarE to access PSUM in parallel (a restriction lifted from NC-v2).
 
-A Trainium NeuronCore has a systolic Tensor Engine — TPU-like — plus three other engines: a Vector Engine for element-wise / reduction operations, a Scalar Engine for small-count arithmetic, and a GpSimd engine for RNG and bit manipulation. NKI exposes all four through a single Python-embedded DSL.
+**ScalarEngine** — pointwise non-linear ops (GELU, SIGMOID, EXP, bias+scale).
 
-The tile shapes are fixed: 128 on the partition axis, up to 512 on the moving axis. That's TPU-like in being systolic-array-sized. But within a tile, NKI gives you per-engine control — SBUF loads explicit, PSUM accumulation explicit, engine dispatch explicit. That's NVIDIA-like in granularity.
+**GpSimdEngine** — 8 fully-programmable 512-bit general-purpose vector cores running straight-line C/C++ via Neuron Custom C++ Operators. Each has its own integrated DMA engine on NC-v3. This is the most under-appreciated Trainium feature: it lets the suite offload control flow, rank-revealing logic, adaptive-precision decisions, sparse index computation, and RNG to a Turing-complete engine without leaving the chip or blocking the TensorEngine. trnrand's Philox kernel targets GpSimdE directly.
 
-The result is a programming model that looks coarse at the macro level (you think in tiles) and fine at the micro level (you schedule engines). It is neither pure SIMT nor pure systolic dataflow. It sits in between.
+**PSUM** — 2 MiB dedicated FP32 accumulation buffer, the exclusive write target of the systolic array, addressable by VectorE/ScalarE/GpSimdE for post-processing. SBUF is 24 MiB on NC-v2, 28 MiB on NC-v3, organized as 128 partitions × (192 or 224) KiB.
 
-## Same workload, three idioms
+**Trainium3** (re:Invent 2025, 3nm process): 2.52 PFLOPs FP8 per chip, 144 GB HBM3e at 4.9 TB/s, MXFP8 and MXFP4 microscaled formats per OCP specification, NeuronSwitch-v1 all-to-all fabric for 144-chip UltraServers at 20.7 TB shared HBM3e and 362 MXFP8 PFLOPs. The MXFP formats are the hardware realization of the per-block precision assumptions that mixed-precision HODLR, BLR-LU, and progressive-precision multigrid have been assuming in theory.
 
-A few representative primitives, expressed in each model:
+---
+
+## Four architectural principles for scientific computing
+
+### 1. PSUM is a free FP32 accumulator
+
+PSUM is wider than SBUF (FP32 vs BF16/FP8), exclusively written by the systolic array (deterministic order), and addressable by every other engine. This makes PSUM the natural target for error-free transformations at systolic scale:
+
+- After a BF16 matmul writes C = A⊗B into PSUM at FP32, VectorE can compute the BF16 split C_hi = fl(C) and the residual C_lo = C − C_hi in PSUM — an in-place error-free split — while the next TensorEngine matmul proceeds on the next tile. The Ogita–Rump–Oishi Dot2 construction becomes the default rather than an expensive overlay.
+- For iterative refinement (Carson–Higham), PSUM *is* the high-precision residual buffer: compute r = b − Ax with A and x in BF16, accumulate in FP32 in PSUM, downcast with SR. The inner loop can live entirely on-chip.
+- trnblas Phase 2 target (trnblas#22): a `nc_matmul_compensated` kernel delivering FP32-accuracy output from BF16 inputs at roughly 2× the work of naive BF16 matmul, exploiting PSUM as the hidden FP32 accumulator.
+
+### 2. Engine concurrency is free adaptivity
+
+The four engines run independently and overlap. This lets trnsci amortize adaptive logic:
+
+- **Adaptive Ozaki splitting.** TensorEngine runs the k-th Ozaki split-product; simultaneously VectorE estimates the residual norm to decide whether to stop. The adaptive decision has effectively zero marginal cost because it runs on the idle engine.
+- **GMRES-IR inner orthogonalization.** The Arnoldi Gram–Schmidt sweep runs on VectorE while TensorEngine runs the next Krylov matvec. trnsolver's cg/gmres paths have the scaffolding; exploitable once Phase 2's compensated-dot primitives land.
+- **Randomized sketching.** For Hutch++ trace estimation, the m/3 Hutchinson queries run on VectorE while TensorEngine builds the low-rank projector Q.
+
+### 3. Stochastic rounding is in the ISA
+
+Per the Neuron rounding-modes documentation: from NeuronCore-v2 onward, stochastic rounding is programmable per-instruction in NKI/NISA and globally via `NEURON_RT_STOCHASTIC_ROUNDING_EN=1`. Connolly, Higham, and Mary (SIAM J. Sci. Comput., 2021) proved SR rounding errors are mean-zero — which replaces Wilkinson's worst-case n·u inner-product error bound with a √n·u probabilistic bound. This is not a nice-to-have; it is a correctness requirement for BF16 Krylov on long sequences. For BF16 (u ≈ 2⁻⁸), any dot product of length n ≥ ~300 should use SR. Trainium makes this free; most other hardware requires CPU fallback or significant overhead to achieve it.
+
+### 4. Determinism is structural
+
+The TensorEngine has a fixed reduction order; the compiler statically schedules all instructions and DMAs. Bitwise reproducibility is a structural property of trnsci kernels given a fixed seed — not a ReproBLAS-style overlay with 4–10× overhead. The only non-determinism is seeded SR, which is reproducible across runs.
+
+---
+
+## Trainium between SM and TPU
+
+Architecturally, Trainium sits between NVIDIA's SIMT model and Google's TPU compiler-mediated model:
+
+| Characteristic | NVIDIA SM | Google TPU | Trainium NKI |
+|---|---|---|---|
+| Programming model | Per-thread SIMT | Per-tensor XLA | Per-tile, per-engine Python |
+| Tile size | Warp (32 lanes) + WMMA | Large systolic slice | 128 × (up to 512) fixed |
+| Memory management | Shared memory (explicit) | Compiler-managed | SBUF/PSUM explicit; 128 partitions |
+| Control flow | Full (GPU branches) | Graph-static | Static in `affine_range`; GpSimd for irregular |
+| Precision control | Via cuBLAS/cuFFT APIs | Via XLA ops | Per-instruction in NKI |
+| Stochastic rounding | No (vendor SR is black-box) | No | ISA-level, per-instruction |
+| Accumulator | Hidden in WMMA | Compiler-managed | Named PSUM, addressable by all engines |
+
+Same workload expressed in each model:
 
 | Primitive | NVIDIA SM | Google TPU | Trainium NKI |
 |---|---|---|---|
-| GEMM tile | Warp-level MMA (wmma / cutlass) | HLO DotGeneral on MXU | `nisa.nc_matmul` stationary + moving |
-| Butterfly stage of FFT | Per-thread complex multiply-add | XLA fused reduction + permute | Per-engine: TE multiply, VE add, SBUF swap |
-| Jacobi rotation | Warp of threads updates two rows | HLO scatter with permutation | TE matmul pair + VE reduction to find max |
-| SpMV | Warp per row, shared indices | Challenging — sparsity hostile to XLA | DMA gather, TE matmul dense tile, DMA scatter |
+| GEMM tile | Warp-level MMA (WMMA / cutlass) | HLO DotGeneral on MXU | `nisa.nc_matmul` stationary + moving into PSUM |
+| Compensated matmul | cuBLAS + separate kernel | Not standard | TensorEngine matmul → PSUM split via VectorE |
+| FFT butterfly stage | Per-thread complex multiply-add | XLA fused reduction + permute | TE multiply, VE add, SBUF swap |
+| Jacobi rotation | Warp updates two rows | HLO scatter | TE matmul pair + VE reduction to find max |
+| Stochastic rounding | N/A or separate kernel | N/A | `nisa.activation(..., round_mode="stochastic")` |
+| Integer bit logic (RNG) | CUDA thread, shared mem | N/A (JAX) | GpSimdE straight-line C |
 
-None of these is a declaration that one architecture is better. The takeaway is that the idioms *translate*. A CUDA programmer reading `trnsci` source can see the mapping. A TPU programmer can see the scheduled tile structure.
+---
 
-## Implication for the suite
+## What fits and what doesn't
 
-The design of each `trnsci` library reflects this middle position:
+| Area | Fit | Notes |
+|---|---|---|
+| Dense LU / QR / Cholesky / SVD | ✅ Clean | Flagship; DF-MP2 validated PySCF to nanohartree |
+| Krylov (CG, GMRES, BiCGStab) | ✅ Clean with SR | SR required for BF16 convergence at n ≫ 300 |
+| Block-sparse at 128×128 (BSR) | ✅ Clean | Native tile match; CSR is interop only |
+| Hierarchical-matrix BLR/HODLR | ✅ Clean | Phase 2+ opportunity; mixed-precision bounds proved |
+| FFT at small N | ✅ Clean | DFT-as-GEMM up to 14× at N ≤ 256 |
+| FFT at large N | Partial | Error accumulates over log₂(N) stages; compensated butterfly + iterative refinement under development |
+| Randomized NLA (RSVD, Hutch++) | ✅ Clean | Only need approximate arithmetic; Phase 3 flagship |
+| Monte Carlo / QMC | ✅ Clean | SR-tolerant by construction |
+| Tensor contractions / einsum | ✅ Clean | DF-MP2 validated end-to-end |
+| Eigensolvers (Jacobi, Householder) | ✅ Clean | Jacobi is a natural NKI kernel (each rotation = 2-row matmul) |
+| Mixed-precision multigrid | ✅ Clean | Phase 3 opportunity; progressive-precision framework fits |
+| Direct sparse solvers (multifrontal) | Partial | Frontal-matrix updates fit; symbolic analysis on GpSimdE |
+| ODE integrators (defect correction) | Partial | Stiff linear/semilinear fits; long nonlinear trajectories do not |
+| Long MD trajectories | ❌ Doesn't fit | 10⁸–10¹² steps accumulate roundoff; FP32 is marginal |
+| Classical CCSD(T) | ❌ Partial | Near-cancellation in correlated sums needs compensated summation everywhere; gated on trnblas#22 |
+| Unstructured CSR SpMV | ❌ Doesn't fit | Irregular access hostile to systolic arrays; use CPU fallback |
 
-- The **API surface** is PyTorch-first, so users don't see the tiling at all most of the time. This is TPU-style — declarative.
-- The **NKI kernels underneath** are hand-written per-engine. This is NVIDIA-style — explicit kernel authorship.
-- The **algorithm choices** (Jacobi eigh, gather-matmul-scatter SpMM, Bluestein for non-power-of-2 FFT) favour ones that map cleanly to the fixed tile shape. This is TPU-pragmatic.
+---
 
-The project's bet is that this middle position is productive for scientific computing in particular — the workloads are dense and fixed-shape enough to enjoy systolic acceleration, but varied enough to need per-engine control.
+## Scale-out
+
+Trn1: 2 NeuronCore-v2 per chip, 2D torus across 16 chips per instance (800 Gbps EFAv2).
+
+Trn2: 8 NeuronCore-v3 per chip, 1 TB/s chip-to-chip, 2D torus within instance. Trn2 UltraServer: 64 chips, 512 NeuronCore-v3, 6 TB shared HBM, 185 TB/s aggregate, 12.8 Tbps EFAv3. 83.2 PFLOPS FP8 dense per UltraServer.
+
+Trn3: NeuronSwitch-v1 all-to-all fabric, 144 chips per UltraServer, 20.7 TB HBM3e, 362 MXFP8 PFLOPs. Dedicated collective-compute engines run in parallel with core compute — overlapping residual-estimation matvecs with the next Ozaki split.
+
+The scale-out topology is embarrassingly parallel for Monte Carlo, randomized NLA (RSVD with independent Gaussian sketches per chip), and ensemble PDE workflows. The trnsci Phase 4 roadmap targets these workloads: sharded tensor abstractions, collective ops, and dispatch glue that makes multi-chip operation transparent from the user's perspective.

--- a/docs/why.md
+++ b/docs/why.md
@@ -1,34 +1,62 @@
 # Why trnsci exists
 
-## The gap
+## The practical reason
 
-A programmer targeting an NVIDIA GPU for a scientific workload reaches, by reflex, for the CUDA library ecosystem. cuFFT handles the transforms. cuBLAS does the dense linear algebra. cuRAND gives reproducible random draws. cuSOLVER factors and diagonalizes. cuSPARSE handles the sparse-matrix path. cuTENSOR does general tensor contractions. Each library is decades of accumulated numerical care — stable algorithms, careful precision handling, tuned kernels.
+A programmer targeting an NVIDIA GPU for a scientific workload reaches, by reflex, for the CUDA library ecosystem: cuFFT for transforms, cuBLAS for dense linear algebra, cuRAND for reproducible random draws, cuSOLVER for factorizations and eigendecomposition, cuSPARSE for sparse-matrix operations, cuTENSOR for general tensor contractions. Each library is decades of accumulated numerical care — stable algorithms, careful precision handling, tuned kernels.
 
-On AWS Trainium, there is no equivalent.
+On AWS Trainium, there is no equivalent. The Neuron SDK ships NKI, a tile-level programming model for the NeuronCore engines, plus fused kernels for transformer training. That covers one workload very well. It does not cover what a computational scientist encounters most days: a spectral method, a density-fit correlation energy, a Monte Carlo integration, a sparse solver, a tensor decomposition.
 
-The Neuron SDK ships NKI, a tile-level programming model for the NeuronCore engines, plus a set of fused kernels targeting transformer training. That covers one workload — LLM training — very well. It does not cover the workloads a computational scientist encounters most days: a spectral method, a density-fit correlation energy, a Monte Carlo integration, a sparse solver, a tensor decomposition.
+trnsci fills that gap: six libraries mirroring the CUDA cu\* split, Python-first APIs with PyTorch fallback on any hardware, and NKI kernels underneath for Neuron acceleration. See the [CUDA → trnsci Rosetta stone](cuda_rosetta.md) for the symbol-by-symbol mapping.
 
-If you want to run any of these on Trainium today, you hand-roll. The cost is high enough that most people don't bother — they move the workload to an NVIDIA instance even when Trainium has the cost or availability advantage.
+## The deeper reason
 
-## Why fill it
+The practical reason is just software coverage. The deeper reason is architectural timing.
 
-Trainium has economics that favour dense, fixed-shape scientific kernels. The systolic Tensor Engine is very well suited to GEMM-heavy workloads — which is to say, most of scientific computing's hot path. Per-FLOP and per-dollar, Trainium is competitive. The gap between that economic case and the observable reality — everyone running LLMs, nobody running eigensolvers — is almost entirely a software-coverage problem.
+Every major silicon roadmap from 2022 onward has converged on the same design: a **tensor-native core with FP32 accumulate on BF16/FP8/FP4 inputs, FP64 either halved, emulated, or absent**. On H100, FP64 tensor throughput is already 1:14.8 versus BF16. On B200 it is 1:61. On B300 Ultra, NVIDIA's own datasheets show FP64 tensor throughput under 1 TFLOPS; cuBLAS in CUDA 13 now emulates FP64 DGEMM via the Ozaki scheme on FP8 tensor cores. AMD halved FP64 matrix throughput from MI300X to MI355X in the same generation that added FP4/FP6. Google TPU has never exposed FP64. Intel Gaudi 3, Cerebras WSE-3, SambaNova SN40L — none.
 
-A library stack closes that gap. Once `trnblas.gemm` does what `cublasSgemm` does, the existing literature of quantum chemistry, computational fluid dynamics, and signal processing becomes portable to Trainium without per-project rewrites.
+Trainium was designed without an FP64 legacy to protect. It is not late to this trend. It codified it in 2020, roughly five years before the industry caught up. Trainium3 (re:Invent 2025, 3nm, 2.52 PFLOPs FP8 per chip) extends this with MXFP8/MXFP4 microscaled formats — which are not incidental to scientific computing: per-block scale factors are exactly the structure that mixed-precision iterative refinement, Ozaki decomposition, and hierarchical-precision block methods have been assuming in theory for years.
 
-## Why this shape
+The numerical-analysis community has been building the framework for this hardware for over a decade. Buttari and Dongarra (2007) showed mixed-precision iterative refinement delivers FP64 accuracy at FP32+FP16 cost. Carson and Higham (2017–2018) generalized this to three-precision GMRES-IR with convergence to κ∞(A) ≲ 10⁷. Halko, Martinsson, and Tropp (2011) built randomized SVD on the observation that algorithms only need approximate arithmetic where statistical error dominates anyway. Connolly, Higham, and Mary proved stochastic rounding makes BF16 Krylov solvers converge to their theoretical floor where round-to-nearest stagnates. Ozaki, Ogita, and colleagues showed how to recover FP64 accuracy from FP8/BF16 tensor units via slice decomposition — which is now in cuBLAS.
 
-The six-library split mirrors the CUDA stack on purpose. The community around NVIDIA's ecosystem has spent a decade internalizing the cuFFT/cuBLAS/cuSOLVER/cuSPARSE taxonomy. Rebuilding that taxonomy on Trainium means a programmer coming from CUDA already knows where to look. The [Rosetta-stone mapping](cuda_rosetta.md) is the primary documentation artefact — every cu\* symbol should have a visible `trn*` analog.
+What was missing was a **coherent library** treating these ideas as the default API rather than exotic overlays on an FP64-centric LAPACK stack. trnsci is that library.
 
-The other reason is composition. A real scientific workload touches four or five of these libraries in a single run. A density-fitted MP2 correlation energy needs Cholesky (solver), dense GEMMs (BLAS), einsum contractions (tensor), integral screening (sparse), and sometimes stochastic trace estimators (RNG). Owning all six in one suite means the cross-library composition is our test case, not an afterthought. See `examples/quantum_chemistry/df_mp2_synthetic.py` for the concrete pattern.
+## What Trainium actually exposes
 
-## Non-goals
+Trainium2's NeuronCore-v3 contains:
 
-- **Not a replacement for the Neuron SDK's transformer kernels.** LLM training is a separate specialty with production-grade kernels already shipping.
-- **Not a deep-learning framework.** Use PyTorch-XLA or `torch_neuronx` for that.
-- **Not a benchmark competition with CUDA.** We are not claiming faster FFTs than cuFFT. We are claiming *any* FFT, plus a consistent path to NKI-accelerated FFT once the kernels land.
-- **Not scope creep into arbitrary numerical libraries.** The six-library boundary is drawn deliberately and matches the CUDA stack; new libraries join the suite only when there is a durable analog in the CUDA ecosystem.
+- A **128×128 systolic array** that accumulates BF16/FP8 matmul products **into a dedicated FP32 PSUM buffer** — the free wider accumulator the Carson–Higham framework has been asking accelerators to expose. Unlike NVIDIA tensor cores, PSUM is named, sized, and addressable by every other engine.
+- **Per-instruction stochastic rounding in the ISA** — not a runtime flag, a per-instruction argument in NKI. This turns BF16 Krylov convergence from aspirational to structural.
+- **Deterministic static scheduling** — the compiler schedules all instructions and DMAs; hardware semaphores synchronize engines. Bitwise reproducibility is a structural guarantee, not a ReproBLAS-style overlay.
+- **Four independently-operating engines** (Tensor, Vector, Scalar, GpSimd) that run concurrently — adaptive precision decisions (the Ozaki stopping criterion, GMRES-IR residual norm) can run on VectorE/GpSimdE while the TensorEngine runs the next matmul.
+- **NKI** — an open-source (Apache 2.0) MLIR-based Python DSL that exposes the full hardware surface, including `nisa.nc_matmul`, `nisa.activation` with rounding-mode control, direct SBUF/PSUM allocation, and GpSimd programming for arbitrary integer logic.
 
-## Status
+Trainium3 adds 144 GB HBM3e at 4.9 TB/s, MXFP8/MXFP4 per-block microscaling, and a NeuronSwitch-v1 all-to-all fabric for 144-chip UltraServers. The MXFP formats are the hardware realization of the per-block precision assumptions that mixed-precision HODLR, BLR-LU, and progressive-precision multigrid have been writing theorems about.
 
-Alpha. Every public API is wired through a PyTorch fallback, so the whole suite runs on a laptop for development. NKI kernels exist as scaffolds — the dispatch layer is in place and picks `nki` over `pytorch` when Neuron hardware is present, but the kernels themselves currently forward to PyTorch. Hardware validation on trn1 / trn2 is the near-term milestone.
+## What fits and what doesn't
+
+The thesis is not that all scientific computing belongs on Trainium. The honest verdicts:
+
+**Fits cleanly:** dense linear algebra (LU, QR, Cholesky, SVD, eigensolvers), Krylov solvers (CG, GMRES, BiCGStab) with SR-enabled BF16 matvec, block-sparse at 128×128 (natural match to the systolic partition dimension), FFT via DFT-as-GEMM at small N and Stockham decompositions at larger N, Monte Carlo and QMC (SR-tolerant by construction), tensor contractions for quantum chemistry (DF-MP2 end-to-end matches PySCF to nanohartree), randomized NLA (RSVD, Hutch++ — only need approximate arithmetic where statistical error dominates).
+
+**Partial fit:** general sparse SpMV (CSR is hostile to systolic arrays; BSR at 128×128 and hierarchical-matrix compression work well for structured sparsity), FFT at large N (precision accumulates across log₂(N) butterfly stages; compensated butterfly and iterative FFT refinement are the engineering response), classical CCSD(T) (correlated methods accumulate cancellation error that requires compensated summation everywhere).
+
+**Doesn't fit:** long-trajectory molecular dynamics (10⁸–10¹² time steps accumulate roundoff that FP32 doesn't solve and BF16 makes worse), fully unstructured sparse SpMV (the PyTorch CPU fallback is the right choice there).
+
+trnsci says this explicitly in its documentation rather than pretending universal applicability. The areas that fit are a substantial fraction of scientific computing's FLOPs — dense LA, Krylov, randomized, MC, PDE discretization, tensor contractions — and they fit very well.
+
+## The API contract
+
+The long-term API direction is not a precision knob. It is a **solve-to-target-error contract**:
+
+```python
+x, info = trnsolver.solve(A, b, target_forward_error=1e-10)
+```
+
+trnsci selects factorization precision, residual precision, Ozaki split count, IR iteration count, and SR policy automatically. The `info` struct returns achieved forward error, the theorems invoked to bound it, and the precision trajectory used. This is the operational realization of Higham's "accuracy as a resource" thesis and what serious HPC users actually want — LAPACK's `?GESV` is silent on achieved forward error and returns garbage on ill-conditioned inputs. trnsolver's existing `iterative_refinement=True` flag and trntensor's `precision=` kwarg are the in-place scaffolding; the unified `target_forward_error` contract across the suite is the Phase 2/3 API deliverable.
+
+## What this is not
+
+- **Not a replacement for the Neuron SDK's transformer kernels.** LLM training has production-grade kernels already shipping; trnsci targets the orthogonal space.
+- **Not a deep-learning framework.** PyTorch or JAX for that.
+- **Not a claim of faster FFTs than cuFFT on N=2²⁰.** Trainium is sized for large sustained GEMMs; the per-op comparisons depend heavily on shape and context. The goal is certified accuracy at stated forward-error tolerances, not peak TFLOPS.
+- **Not AWS-affiliated.** trnsci is an independent open-source project under Apache 2.0. The benchmarks and architectural takes are third-party observations, not AWS product claims. See the [disclaimer](disclaimer.md).


### PR DESCRIPTION
Updates three public docs to incorporate the post-FP64 positioning and technical plan v3 insights.

## why.md
Rewritten to lead with the post-FP64 thesis rather than "Neuron SDK doesn't ship cuFFT." Grounds the argument in a decade of mixed-precision NLA literature (Carson–Higham, Ozaki, Croci–Higham–Mary), adds the `target_forward_error` API contract direction, updates status to reflect Phase 1 progress across the suite, and adds explicit honest "doesn't fit" verdicts (long MD, classical CCSD(T), unstructured CSR SpMV).

## trainium_positioning.md
Major update:
- Competitive landscape table showing H100→B300 FP64 decline and cuBLAS CUDA 13 Ozaki emulation
- Trn3 hardware facts (2.52 PFLOPs FP8, 144 GB HBM3e, MXFP8/MXFP4, NeuronSwitch-v1)
- Four architectural principles: PSUM-as-EFT-accumulator, engine-concurrency-as-free-adaptivity, SR-in-ISA, determinism-as-structural-property
- Updated SM-vs-TPU comparison table with SR and PSUM rows
- Full fit/doesn't-fit table for all workload areas

## roadmap.md
- Phase 2 description updated with trnblas#22 as keystone, target_forward_error API, SR-enabled Krylov, and HPL-MxP validation target
- Phase 3 description updated with RandNLA flagship (rsvd/Hutch++/sRR) and HPL-MxP multi-node submission
- Phase 5 updated with Trn3 MXFP8/MXFP4 and research contributions
- "Where each library is today" updated to April 2026 versions and actual validation state

Tracking issues filed: trnsci/trnsci#36 (RandNLA flagship), #37 (HPL-MxP), #38 (target_forward_error API), #39 (CUDA samples).